### PR TITLE
handle missing options.json

### DIFF
--- a/nginx/nginx.sh
+++ b/nginx/nginx.sh
@@ -3,15 +3,17 @@
 CONF_FILE=/etc/nginx/conf.d/default.conf
 OPTIONS_FILE=$DATA_DIR/options.json
 
-# Get values from options.json
-if [ -f "$OPTIONS_FILE" ]; then
-    DOMAIN=$(jq -r '.domain? // ""' $OPTIONS_FILE)
-    CDNDOMAIN=$(jq -r '.cdn_domain? // "cdn.iplayif.com"' $OPTIONS_FILE)
-    HTTPS=$(jq -r '.https? // false' $OPTIONS_FILE)
-    RELOAD_TIME=$(jq -r '.nginx?.reload_time? // 360' $OPTIONS_FILE)
-    SECONDARY_DOMAIN=$(jq -r '.secondary_domain? // ""' $OPTIONS_FILE)
-    WWW=$(jq -r '.www? // false' $OPTIONS_FILE)
+if [ ! -f "$OPTIONS_FILE" ]; then
+    echo "{}" > "$OPTIONS_FILE"
 fi
+
+# Get values from options.json
+DOMAIN=$(jq -r '.domain? // ""' $OPTIONS_FILE)
+CDNDOMAIN=$(jq -r '.cdn_domain? // "cdn.iplayif.com"' $OPTIONS_FILE)
+HTTPS=$(jq -r '.https? // false' $OPTIONS_FILE)
+RELOAD_TIME=$(jq -r '.nginx?.reload_time? // 360' $OPTIONS_FILE)
+SECONDARY_DOMAIN=$(jq -r '.secondary_domain? // ""' $OPTIONS_FILE)
+WWW=$(jq -r '.www? // false' $OPTIONS_FILE)
 
 if [ "$WWW" = "true" ]; then
     WWW_DOMAIN="www.$DOMAIN"


### PR DESCRIPTION
Without this, `docker compose up` fails out-of-the-box when you try to launch `iplayif.com` with no `data/options.json` file.

```
iplayifcom-nginx-1    | 10-listen-on-ipv6-by-default.sh: info: /etc/nginx/conf.d/default.conf differs from the packaged version
iplayifcom-nginx-1    | /docker-entrypoint.sh: Sourcing /docker-entrypoint.d/15-local-resolvers.envsh
iplayifcom-nginx-1    | /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
iplayifcom-nginx-1    | /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
iplayifcom-nginx-1    | /docker-entrypoint.sh: Configuration complete; ready for start up
iplayifcom-nginx-1    | 2023/09/14 03:20:24 [emerg] 9#9: no host in upstream "" in /etc/nginx/conf.d/default.conf:23
iplayifcom-nginx-1    | nginx: [emerg] no host in upstream "" in /etc/nginx/conf.d/default.conf:23
iplayifcom-nginx-1 exited with code 1
```