### PR TITLE
Allow 100mb files to be uploaded to the converter

### DIFF
--- a/nginx/nginx.sh
+++ b/nginx/nginx.sh
@@ -78,6 +78,8 @@ server {
     $SSL
     $GZIP
 
+    client_max_body_size 100M;
+
     location = / {
         proxy_pass http://app:8080;
     }


### PR DESCRIPTION
This sets `client_max_body_size 100M`.

The default value for [`client_max_body_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) is 1M, which is too small for many Glulx games. (I wasn't able to convert "The Wizard Sniffer" without applying this change.)

The largest file in IFArchive with one of the known-good extensions (blb blorb taf hex gblorb glb ulx gam t3 zblorb zlb z3 z4 z5 z8) is https://ifarchive.org/if-archive/games/competition2008/glulx/amo/AMO.blb which is 50MB (it includes music).